### PR TITLE
Update wiki links to wiki.gg

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ outputs, and adhere to any given constraints.
 
 ## Acknowledgements
 
-- Images are taken from the [Official Satisfactory Wiki](https://satisfactory.gamepedia.com/Satisfactory_Wiki).
+- Images are taken from the [Official Satisfactory Wiki](https://satisfactory.wiki.gg/Satisfactory_Wiki).
 
 ## Contributing
 

--- a/ada/db/crafter.py
+++ b/ada/db/crafter.py
@@ -38,7 +38,7 @@ class Crafter(Entity):
 
     def wiki(self):
         return (
-                "https://satisfactory.fandom.com/wiki/" + self.human_readable_underscored()
+                "https://satisfactory.wiki.gg/wiki/" + self.human_readable_underscored()
         )
 
     def thumb(self):

--- a/ada/db/extractor.py
+++ b/ada/db/extractor.py
@@ -52,7 +52,7 @@ class Extractor(Entity):
 
     def wiki(self):
         return (
-                "https://satisfactory.fandom.com/wiki/" + self.human_readable_underscored()
+                "https://satisfactory.wiki.gg/wiki/" + self.human_readable_underscored()
         )
 
     def thumb(self):

--- a/ada/db/item.py
+++ b/ada/db/item.py
@@ -108,7 +108,7 @@ class Item(Entity):
 
     def wiki(self) -> str:
         return (
-                "https://satisfactory.fandom.com/wiki/" + self.human_readable_underscored()
+                "https://satisfactory.wiki.gg/wiki/" + self.human_readable_underscored()
         )
 
     def thumb(self) -> str:

--- a/ada/db/power_generator.py
+++ b/ada/db/power_generator.py
@@ -70,7 +70,7 @@ class PowerGenerator(Entity):
 
     def wiki(self):
         return (
-                "https://satisfactory.fandom.com/wiki/" + self.human_readable_underscored()
+                "https://satisfactory.wiki.gg/wiki/" + self.human_readable_underscored()
         )
 
     def thumb(self):


### PR DESCRIPTION
The Official Satisfactory Wiki has moved to https://satisfactory.wiki.gg/, updated the links accordingly.

Reference: https://www.youtube.com/clip/Ugkxbz8k7eWIF7V2wEGozljsSrLoJm2o9UfU